### PR TITLE
Added clickable navigation to Recent Trips title

### DIFF
--- a/app/src/main/java/com/example/citiway/core/ui/components/Drawer.kt
+++ b/app/src/main/java/com/example/citiway/core/ui/components/Drawer.kt
@@ -323,10 +323,10 @@ fun ModernSettingsMenu(
 
                     HorizontalDivider()
 
-                    // Favorites Page
-                    // Clicking navigates to favorites
+                    // Favourites Page
+                    // Clicking navigates to favourites
                     MenuItemClickable(
-                        title = "Favorites",
+                        title = "Favourites",
                         subtitle = "Saved trips and preferred routes",
                         onClick = {
                             onDismiss()

--- a/app/src/main/java/com/example/citiway/core/utils/Previews.kt
+++ b/app/src/main/java/com/example/citiway/core/utils/Previews.kt
@@ -38,6 +38,7 @@ fun HomeScreenPreview() {
         onMapIconClick = {},
         onSelectPrediction = { prediction, placesManager -> },
         onFavouritesTitleClick = {},
+        onRecentTitleClick = {}
     )
 
     CitiWayTheme {

--- a/app/src/main/java/com/example/citiway/features/home/HomeContent.kt
+++ b/app/src/main/java/com/example/citiway/features/home/HomeContent.kt
@@ -59,7 +59,8 @@ fun HomeContent(
         CompletedTripsSection(
             completedJourneysState.recentJourneys,
             actions.onToggleFavourite,
-            "Recent Trips"
+            "Recent Trips",
+            onTitleClick = actions.onRecentTitleClick
         )
         VerticalSpace(24)
 

--- a/app/src/main/java/com/example/citiway/features/home/HomeRoute.kt
+++ b/app/src/main/java/com/example/citiway/features/home/HomeRoute.kt
@@ -24,6 +24,7 @@ data class HomeActions(
     val onMapIconClick: () -> Unit,
     val onSelectPrediction: (AutocompletePrediction, PlacesManager) -> Unit,
     val onFavouritesTitleClick: () -> Unit,
+    val onRecentTitleClick: () -> Unit,
 )
 
 @Composable
@@ -58,7 +59,8 @@ fun HomeRoute(
         { navController.navigate(Screen.Schedules.route) },
         { navController.navigate(Screen.DestinationSelection.route) },
         onSelectPrediction,
-        onFavouritesTitleClick = {navController.navigate(Screen.Favourites.route)}
+        onFavouritesTitleClick = {navController.navigate(Screen.Favourites.route)},
+        onRecentTitleClick = {navController.navigate(Screen.JourneyHistory.route)}
     )
 
     ScreenWrapper(navController, true, { paddingValues ->


### PR DESCRIPTION
Made the "Recent Trips" heading clickable to match the Favourite Trips behavior, allowing users to navigate to a dedicated recent trips screen by tapping the title.